### PR TITLE
feat: parse news.md to news_parsed.json and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@
    ```
 2. 뉴스 데이터를 JSON 형식으로 변환합니다.
    ```bash
-   python scripts/news_to_json.py
+   python scripts/py/news_to_json.py
    ```
 3. 이후 다른 빌드 스텝(`python scripts/make_charts.py`, `python scripts/build_html.py` 등)을 실행합니다.

--- a/data/news_parsed.json
+++ b/data/news_parsed.json
@@ -1,62 +1,52 @@
 [
   {
-    "date": "2025-05-12",
-    "headline": "로보택시 조사 확대",
-    "src": "Reuters"
+    "date": "2025-05-16",
+    "src": "Reuters",
+    "headline": "이사회 개편"
   },
   {
-    "date": "2025-05-12",
-    "headline": "주가 움직임",
-    "src": "Investopedia"
+    "date": "2025-05-16",
+    "src": "Electrek",
+    "headline": "로보택시 운영 모드 공개"
+  },
+  {
+    "date": "2025-05-15",
+    "src": "Reuters",
+    "headline": "리스 차량 회수‧매각 논란"
+  },
+  {
+    "date": "2025-05-15",
+    "src": "Electrek",
+    "headline": "브랜드 이미지 타격"
+  },
+  {
+    "date": "2025-05-15",
+    "src": "블룸버그",
+    "headline": "소송 문턱 상향"
+  },
+  {
+    "date": "2025-05-14",
+    "src": "Reuters",
+    "headline": "중국 부품 수입 재개"
+  },
+  {
+    "date": "2025-05-14",
+    "src": "Not A Tesla App",
+    "headline": "소프트웨어 (Spring Update) 분해"
   },
   {
     "date": "2025-05-13",
-    "headline": "모델 Y 부분변경 ‘주니퍼’ 출발 삐걱",
-    "src": "Reuters"
+    "src": "Reuters",
+    "headline": "모델 Y 부분변경 ‘주니퍼’ 출발 삐걱"
   },
   {
-    "date": "2025-05-14",
-    "headline": "중국 부품 수입 재개",
-    "src": "Reuters"
+    "date": "2025-05-12",
+    "src": "Reuters",
+    "headline": "로보택시 조사 확대"
   },
   {
-    "date": "2025-05-14",
-    "headline": "소프트웨어 (Spring Update) 분해",
-    "src": "Not A Tesla App"
-  },
-  {
-    "date": "2025-05-15",
-    "headline": "리스 차량 회수‧매각 논란",
-    "src": "Reuters"
-  },
-  {
-    "date": "2025-05-15",
-    "headline": "브랜드 이미지 타격",
-    "src": "Electrek"
-  },
-  {
-    "date": "2025-05-15",
-    "headline": "소송 문턱 상향",
-    "src": "블룸버그"
-  },
-  {
-    "date": "2025-05-16",
-    "headline": "이사회 개편",
-    "src": "Reuters"
-  },
-  {
-    "date": "2025-05-16",
-    "headline": "로보택시 운영 모드 공개",
-    "src": "Electrek"
-  },
-  {
-    "date": "2025-05-22",
-    "headline": "배터리 업데이트",
-    "src": "Source11"
-  },
-  {
-    "date": "2025-05-23",
-    "headline": "공장 증설 계획",
-    "src": "Source12"
+    "date": "2025-05-12",
+    "src": "Investopedia",
+    "headline": "주가 움직임"
   }
 ]

--- a/scripts/py/news_to_json.py
+++ b/scripts/py/news_to_json.py
@@ -1,0 +1,78 @@
+import json
+import re
+from pathlib import Path
+
+NEWS_MD = Path('data/news.md')
+OUTPUT_JSON = Path('data/news_parsed.json')
+
+
+def parse_news(lines):
+    items = []
+    current_date = None
+    i = 0
+    year = 2025
+    # attempt to detect year from reference links
+    for line in reversed(lines):
+        m_year = re.search(r'(20\d{2})-\d{2}-\d{2}', line)
+        if m_year:
+            year = int(m_year.group(1))
+            break
+    while i < len(lines):
+        line = lines[i].rstrip('\n')
+        stripped = line.strip()
+        m_date = re.match(r'^##\s*(\d+)\s*월\s*(\d+)\s*일', stripped)
+        if m_date:
+            month = int(m_date.group(1))
+            day = int(m_date.group(2))
+            current_date = f"{year}-{month:02d}-{day:02d}"
+            i += 1
+            continue
+        if stripped.startswith('###'):
+            headline = stripped.lstrip('#').strip()
+            i += 1
+            while i < len(lines) and lines[i].strip() == '':
+                i += 1
+            bullet_lines = []
+            while i < len(lines):
+                next_line = lines[i].rstrip('\n')
+                if next_line.strip() == '':
+                    if bullet_lines:
+                        i += 1
+                        break
+                    i += 1
+                    continue
+                if next_line.startswith('##') or next_line.startswith('###') or next_line.startswith('---'):
+                    break
+                if next_line.lstrip().startswith('*'):
+                    bullet_lines.append(next_line.strip())
+                    i += 1
+                    while i < len(lines):
+                        cont = lines[i].rstrip('\n')
+                        if cont.startswith('##') or cont.startswith('###') or cont.startswith('---'):
+                            break
+                        if cont.lstrip().startswith('*'):
+                            break
+                        bullet_lines.append(cont.strip())
+                        i += 1
+                    break
+                else:
+                    i += 1
+            bullet_text = ' '.join(bullet_lines)
+            m_src = re.search(r'\(\[([^\]]+)\]\[[0-9]+\]\)', bullet_text)
+            if m_src and current_date:
+                src = m_src.group(1).strip()
+                items.append({'date': current_date, 'src': src, 'headline': headline})
+            continue
+        i += 1
+    return items
+
+
+def main():
+    lines = NEWS_MD.read_text(encoding='utf-8').splitlines()
+    items = parse_news(lines)
+    items_sorted = sorted(items, key=lambda x: x['date'], reverse=True)[:10]
+    OUTPUT_JSON.write_text(json.dumps(items_sorted, ensure_ascii=False, indent=2), encoding='utf-8')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_news.py
+++ b/tests/test_news.py
@@ -1,0 +1,16 @@
+import json
+from pathlib import Path
+
+
+def test_news_json_top_10():
+    path = Path('data/news_parsed.json')
+    assert path.exists(), 'data/news_parsed.json should exist'
+
+    data = json.loads(path.read_text(encoding='utf-8'))
+    assert isinstance(data, list)
+    assert len(data) == 10, 'Expected exactly 10 news items'
+
+    for idx, item in enumerate(data):
+        assert 'date' in item, f'Missing date in item {idx}'
+        assert 'src' in item, f'Missing src in item {idx}'
+        assert 'headline' in item, f'Missing headline in item {idx}'


### PR DESCRIPTION
## Summary
- add news_to_json.py to convert `news.md` to JSON
- save top 10 headlines into `data/news_parsed.json`
- add tests validating the parsed JSON
- update README usage path

기존 차트/HTML 관련 파일 (make_report.py, build_chart.mjs 등)과 충돌 없음.
